### PR TITLE
Enable package for 2.12.0 prereleases

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ documentation: https://github.com/jama5262/jiffy/tree/master/doc
 author: Jama Mohamed <jama3137@gmail.com>
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   intl: ^0.17.0


### PR DESCRIPTION
According to [dart.dev](https://dart.dev/null-safety/migration-guide#migrating-by-hand) this enables the usage of 2.12.0 prereleases, which makes the package usable under the current beta channel.